### PR TITLE
New Release 2019-05-15

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Technically, the plugin:
 
   * Firebug console was not added when the language was Babel
   * The output on the console log is now escaped for HTML entities and can then render HTML
+  * There was a bug with the declaration of a variable
   
 ### 2019-02-06
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Technically, the plugin:
   * More language with:
      * [sphere-engine](https://developer.sphere-engine.com/api/compilers) - Online example: https://ideone.com
      * or [codingground](https://www.tutorialspoint.com/codingground.htm)
+  * [Mermaid Graph Library](https://mermaidjs.github.io) as language
+  * Add the console after initial rendering to not select console element via css
   
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Technically, the plugin:
 ## Changes
 
 
-### Current
+### 2019-05-14
 
   * Firebug console was not added when the language was Babel
   * The output on the console log is now escaped for HTML entities and can then render HTML

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base     webcode
 author   Nicolas GERARD
 email    gerardnico@gmail.com
-date     2019-02-06
+date     2019-05-14
 name     Webcode Plugin
 desc     Plugin that shows and adds the result of (web|browser) code (ie HTML, CSS or Javascript)
 url      https://www.dokuwiki.org/plugin:webcode

--- a/syntax/basis.php
+++ b/syntax/basis.php
@@ -22,7 +22,7 @@ class syntax_plugin_webcode_basis extends DokuWiki_Syntax_Plugin
     // Simple cache bursting implementation for the webCodeConsole.(js|css) file
     // They must be incremented manually when they changed
     const WEB_CONSOLE_CSS_VERSION = 1.1;
-    const WEB_CONSOLE_JS_VERSION = 1.9;
+    const WEB_CONSOLE_JS_VERSION = 2.0;
 
     /**
      * @var array that holds the iframe attributes

--- a/webCodeConsole.js
+++ b/webCodeConsole.js
@@ -34,7 +34,12 @@ let WEBCODE = {
     },
     htmlEntities: function(str) {
         // from https://css-tricks.com/snippets/javascript/htmlentities-for-javascript/
-        return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/ /g, '&nbsp;');
     }
 };
 
@@ -45,8 +50,7 @@ window.console.log = function (input) {
         s = "{\n";
         let keys = Object.keys(input);
         for (let i = 0; i < keys.length; i++) {
-            // &nbsp; = one space in HTML
-            s += "&nbsp;&nbsp;" + keys[i] + " : " + input[keys[i]] + ";\n";
+            s += "  " + keys[i] + " : " + input[keys[i]] + ";\n";
         }
         s += "}\n";
     } else {
@@ -76,7 +80,6 @@ window.console.table = function (input) {
             let theadElement = document.createElement("thead");
             let tbodyElement = document.createElement("tbody");
             let trElement = document.createElement("tr");
-            let tdElement = document.createElement("td");
 
             tableElement.appendChild(theadElement);
             tableElement.appendChild(tbodyElement);
@@ -91,8 +94,8 @@ window.console.table = function (input) {
                 if (i === 0) {
 
                     if (typeof element === 'object') {
-                        for (prop in element) {
-                            var thElement = document.createElement("th");
+                        for (let prop in element) {
+                            let thElement = document.createElement("th");
                             thElement.innerHTML = WEBCODE.print(prop);
                             trElement.appendChild(thElement);
                         }
@@ -109,13 +112,13 @@ window.console.table = function (input) {
                 tbodyElement.appendChild(trElement);
 
                 if (typeof input[0] === 'object') {
-                    for (prop in element) {
-                        var tdElement = tdElement.cloneNode(false);
+                    for (let prop in element) {
+                        let tdElement = document.createElement("td");
                         tdElement.innerHTML = WEBCODE.print(element[prop]);
                         trElement.appendChild(tdElement);
                     }
                 } else {
-                    let tdElement = tdElement.cloneNode(false);
+                    let tdElement = document.createElement("td");
                     tdElement.innerHTML = WEBCODE.print(element);
                     trElement.appendChild(tdElement);
                 }


### PR DESCRIPTION
  * Firebug console was not added when the language was Babel
  * The output on the console log is now escaped for HTML entities and can then render HTML
  * There was a bug with the declaration of a variable that Chrome was not anymore accepting